### PR TITLE
Filled POSITIONS_BY_ITEM

### DIFF
--- a/src/main/java/com/strangeone101/holoitemsapi/CustomItemRegistry.java
+++ b/src/main/java/com/strangeone101/holoitemsapi/CustomItemRegistry.java
@@ -34,7 +34,6 @@ public class CustomItemRegistry {
             if (NEXT_ID == INVALID_ID) NEXT_ID++;
         }
 
-        EventCache.prepareCache(item);
         EventCache.registerEvents(item);
     }
 

--- a/src/main/java/com/strangeone101/holoitemsapi/itemevent/EventCache.java
+++ b/src/main/java/com/strangeone101/holoitemsapi/itemevent/EventCache.java
@@ -194,6 +194,8 @@ public class EventCache {
     }
 
     public static void updateHeldSlot(Player player, int oldSlot, int newSlot) {
+        if (LOG_DEBUG) Bukkit.getLogger().info ("Updating held slot from " + oldSlot + " to " + newSlot);
+
         if (CACHED_POSITIONS_BY_SLOT.containsKey(player)) {
             if (CACHED_POSITIONS_BY_SLOT.get(player).containsKey(oldSlot)) {
                 CACHED_POSITIONS_BY_SLOT.get(player).get(oldSlot).setRight(getPosition(oldSlot, newSlot));
@@ -206,6 +208,14 @@ public class EventCache {
         for (Map<Player, Map<Integer, Pair<ItemStack, Position>>> positionsCache : POSITIONS_BY_ITEM.values()) {
             Map<Integer, Pair<ItemStack, Position>> playerSlotCache = positionsCache.get(player);
             if (playerSlotCache == null) continue;
+
+            if (LOG_DEBUG) {
+                Bukkit.getLogger().info (player.toString() + "'s inventory has:");
+                for (Map.Entry<Integer, Pair<ItemStack, Position>> slots : playerSlotCache.entrySet()) {
+                    Bukkit.getLogger().info ("[" + slots.getKey() + "] : " + slots.getValue().getLeft().toString() + " @ " + slots.getValue().getRight().toString());
+                }
+            }
+
             Pair<ItemStack, Position> transfer;
             transfer = playerSlotCache.get(oldSlot);
             if (transfer != null) {
@@ -216,6 +226,8 @@ public class EventCache {
                 transfer.setValue(getPosition(newSlot, newSlot));
             }
         }
+
+        if (LOG_DEBUG) Bukkit.getLogger().info ("Held slot update end");
     }
 
     public static boolean shouldCache(ItemStack stack) {

--- a/src/main/java/com/strangeone101/holoitemsapi/listener/ItemListener.java
+++ b/src/main/java/com/strangeone101/holoitemsapi/listener/ItemListener.java
@@ -31,7 +31,7 @@ import org.bukkit.event.inventory.*;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
-//import org.bukkit.event.player.PlayerItemHeldEvent;
+import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.AnvilInventory;
@@ -261,13 +261,11 @@ public class ItemListener implements Listener {
         }
     }
 
-    /*
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSlotSwitch(PlayerItemHeldEvent event) {
         //Update the cached held item
         EventCache.updateHeldSlot(event.getPlayer(), event.getPreviousSlot(), event.getNewSlot());
     }
-    */
 
     @EventHandler(ignoreCancelled = true)
     public void onItemSpawn(ItemSpawnEvent event) {

--- a/src/main/java/com/strangeone101/holoitemsapi/listener/ItemListener.java
+++ b/src/main/java/com/strangeone101/holoitemsapi/listener/ItemListener.java
@@ -15,13 +15,10 @@ import com.strangeone101.holoitemsapi.interfaces.Swingable;
 import com.strangeone101.holoitemsapi.itemevent.EventCache;
 import com.strangeone101.holoitemsapi.recipe.RecipeManager;
 import com.strangeone101.holoitemsapi.util.ItemUtils;
+import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
 import org.bukkit.Material;
-import org.bukkit.entity.Cat;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.EntityType;
-import org.bukkit.entity.Player;
-import org.bukkit.entity.Wolf;
+import org.bukkit.entity.*;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -30,19 +27,11 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.block.BlockPlaceEvent;
 import org.bukkit.event.entity.EntityPickupItemEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
-import org.bukkit.event.inventory.BrewingStandFuelEvent;
-import org.bukkit.event.inventory.CraftItemEvent;
-import org.bukkit.event.inventory.InventoryAction;
-import org.bukkit.event.inventory.InventoryClickEvent;
-import org.bukkit.event.inventory.InventoryPickupItemEvent;
-import org.bukkit.event.inventory.InventoryType;
-import org.bukkit.event.inventory.PrepareAnvilEvent;
-import org.bukkit.event.inventory.PrepareItemCraftEvent;
-import org.bukkit.event.inventory.TradeSelectEvent;
+import org.bukkit.event.inventory.*;
 import org.bukkit.event.player.PlayerInteractEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
-import org.bukkit.event.player.PlayerItemHeldEvent;
+//import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerLoginEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.inventory.AnvilInventory;
@@ -136,7 +125,7 @@ public class ItemListener implements Listener {
         new BukkitRunnable() {
             @Override
             public void run() {
-                if (event.getPlayer() == null || !event.getPlayer().isOnline()) {
+                if (!event.getPlayer().isOnline()) {
                     EventCache.release(event.getPlayer());
                 }
             }
@@ -272,11 +261,13 @@ public class ItemListener implements Listener {
         }
     }
 
+    /*
     @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onSlotSwitch(PlayerItemHeldEvent event) {
         //Update the cached held item
         EventCache.updateHeldSlot(event.getPlayer(), event.getPreviousSlot(), event.getNewSlot());
     }
+    */
 
     @EventHandler(ignoreCancelled = true)
     public void onItemSpawn(ItemSpawnEvent event) {
@@ -379,56 +370,45 @@ public class ItemListener implements Listener {
 
         if (!(event.getWhoClicked() instanceof Player) || event.getAction() == InventoryAction.NOTHING) return;
 
-        if (event.getClick().isShiftClick() || event.getInventory().getType() == InventoryType.CREATIVE) { //TODO Rather than doing a full recache, calculate what it SHOULD be
-            cacheLater((Player) event.getWhoClicked());
+        Player player = (Player)(event.getWhoClicked());
+
+        if (event.getInventory().getType() == InventoryType.CREATIVE) {
+            if (DEBUG_MODE) event.getWhoClicked().sendMessage("Dirty flag on: creative inventory");
+            EventCache.DIRTY_INVENTORY.add(player);
             return;
         }
 
-        boolean inPlayerInv = event.getRawSlot() >= event.getInventory().getSize();
-
-        if (event.getAction() == InventoryAction.DROP_ALL_CURSOR || event.getAction() == InventoryAction.DROP_ALL_SLOT
-                || event.getAction() == InventoryAction.DROP_ONE_CURSOR || event.getAction() == InventoryAction.DROP_ONE_SLOT) {
-            if (inPlayerInv || event.getCursor() != null) { //if its in the inv or they are holding an item
-                EventCache.uncacheSlot((Player) event.getWhoClicked(), event.getCursor() != null ? event.getSlot() : -1); //-1 is held itemstack
-            }
+        if (EventCache.shouldCache(event.getCurrentItem()) || EventCache.shouldCache(event.getCursor())) {
+            if (DEBUG_MODE) event.getWhoClicked().sendMessage("Dirty flag on: " + event.getAction().toString());
+            EventCache.DIRTY_INVENTORY.add(player);
             return;
         }
 
-        if (event.getAction() == InventoryAction.MOVE_TO_OTHER_INVENTORY) {
-            if (event.getInventory().getType() == InventoryType.CRAFTING) {
-                cacheLater((Player) event.getWhoClicked());
-                return;
+        if (event.getAction() == InventoryAction.HOTBAR_SWAP) {
+            //Special case: swap when a CustomItem is in offhand and cursor points to a regular item
+            if (EventCache.shouldCache(player.getInventory().getItemInOffHand())) {
+                if (DEBUG_MODE) event.getWhoClicked().sendMessage("Dirty flag on: " + event.getAction().toString());
+                EventCache.DIRTY_INVENTORY.add(player);
             }
         }
+    }
 
-        if (event.getAction() == InventoryAction.PICKUP_ALL || event.getAction() == InventoryAction.PICKUP_HALF ||
-                event.getAction() == InventoryAction.PICKUP_ONE || event.getAction() == InventoryAction.PICKUP_SOME) {
-            if (!EventCache.shouldCache(event.getCurrentItem())) return;
+    @EventHandler(ignoreCancelled = true)
+    public void onInventoryClose(InventoryCloseEvent event) {
+        Player player = (Player)event.getPlayer();
 
-
-            if (inPlayerInv) {
-                EventCache.updateCacheSlot((Player) event.getWhoClicked(), event.getSlot(), -1);
-            } else
-                EventCache.cacheItem((Player) event.getWhoClicked(), inPlayerInv ? event.getSlot() : -1, event.getCurrentItem());
-            return;
+        if (EventCache.DIRTY_INVENTORY.contains(player)) {
+            cacheLater(player);
         }
+    }
 
-        if (inPlayerInv) { //If the click WASN'T in the top inventory
-            if (!EventCache.shouldCache(event.getCursor())) return;
-
-            if (event.getCursor() != null) {
-
-                if (event.getCurrentItem() != null && event.getCurrentItem().isSimilar(event.getCursor()) && event.getCurrentItem().getAmount() < event.getCurrentItem().getMaxStackSize()) {
-                    EventCache.uncacheSlot((Player) event.getWhoClicked(), -1); //Delete the cached in item item
-                } else {
-                    EventCache.updateCacheSlot((Player) event.getWhoClicked(), -1, event.getSlot()); //Swap held item and the clicked slot
-                }
-                return;
-            } else if (event.getAction() == InventoryAction.PLACE_ALL || event.getAction() == InventoryAction.PLACE_ONE ||
-                    event.getAction() == InventoryAction.PLACE_SOME) {
-                EventCache.updateCacheSlot((Player) event.getWhoClicked(), -1, event.getSlot());
-            }
-
+    @EventHandler(ignoreCancelled = true)
+    public void onItemDrag(InventoryDragEvent event) {
+        HumanEntity entity = event.getWhoClicked();
+        if (!(entity instanceof Player)) return;
+        if (EventCache.shouldCache(event.getCursor()) || EventCache.shouldCache(event.getOldCursor())) {
+            if (DEBUG_MODE) event.getWhoClicked().sendMessage("Dirty flag: InventoryDragEvent");
+            EventCache.DIRTY_INVENTORY.add((Player)entity);
         }
     }
 


### PR DESCRIPTION
Needs work:
- Swapping between hotbar and inventory
- Dropping item with mouse
- Placing item in Crafting inventory and then closing inventory
- Changing items on the same inventory:
  - Splitting stack in half (right-click and dropping cursor on air slot in inventory)
  - Merging stacks (dropping cursor with item on non full item stack of same type)
  - Swapping stacks (dropping cursor with item on different item in inventory)
- Receiving item (e.g. getting Holocoins from Banker and /givecoins)
- Losing item (e.g. depositing Holocoins to Banker and /takecoins)
- Dropping one item without losing entire stack (Q button)

Seems to be working:
- Picking up item
- Dropping whole stack item with Q button or ctrl+Q
- Using shift key to switch inventories